### PR TITLE
 topology_hwloc : debug cache inclusiveness detection with some core/PU restricted by cgroups

### DIFF
--- a/src/topology_hwloc.c
+++ b/src/topology_hwloc.c
@@ -274,7 +274,12 @@ void hwloc_init_cacheTopology(void)
         cachePool[id].threads = hwloc_record_objs_of_type_below_obj(
                         hwloc_topology, obj, HWLOC_OBJ_PU, NULL, NULL);
 
-        if (info = hwloc_obj_get_info_by_name(obj, "inclusiveness"))
+        while (!(info = hwloc_obj_get_info_by_name(obj, "inclusiveness")) && obj->next_cousin)
+        {
+            obj = obj->next_cousin; // If some PU/core are not bindable because of cgroup, hwloc may not know the inclusiveness of some of their cache.
+        }            
+		
+        if(info)
         {
             cachePool[id].inclusive = info[0]=='t';
         }


### PR DESCRIPTION
Hwloc only annotate the inclusiveness of the cache detected by his x86 backend. It can't detect cache without binding to his PU. 
If at a level the cache detected as 0 by the linux backend has no bindable pu his inclusiveness will be null.
As likwid assume that all the cache at one level are the same, cousin inclusiveness can be used instead.

May fix https://groups.google.com/forum/#!topic/likwid-users/XD6W1z203wE
(unless additional information are provided and cgroup weren't used)